### PR TITLE
Merge changes for v2.1.2

### DIFF
--- a/app/assets/javascripts/my_account/account.js.coffee
+++ b/app/assets/javascripts/my_account/account.js.coffee
@@ -417,7 +417,7 @@ account =
       $.ajax({
         url: "/myaccount/ajax_cancel"
         type: "POST"
-        data: { netid: netid, requestId: id }
+        data: { requestId: id }
         error: (jqXHR, textStatus, error) ->
           account.logError("Unable to cancel request #{id} (#{error})")
           account.updateItemStatus(id, { code: 400 })

--- a/app/views/my_account/account/_checkouts.html.haml
+++ b/app/views/my_account/account/_checkouts.html.haml
@@ -35,8 +35,8 @@
               -# - if @renewable_lookup_hash && @renewable_lookup_hash[c['item']['itemId']] == 'N'
               -#   %div.badge.badge-secondary
               -#     This item cannot be renewed.
-              - if !c['is_bd']
-                %div.source-badge
+              -# - if c['is_bd']
+              %div.source-badge
                 -# %div.badge.badge-primary
                   -# Borrow Direct
               - if c['is_ill']

--- a/lib/my_account/version.rb
+++ b/lib/my_account/version.rb
@@ -1,3 +1,3 @@
 module MyAccount
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end

--- a/my_account.gemspec
+++ b/my_account.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "xml-simple"
   s.add_dependency 'rest-client'
   s.add_dependency 'borrow_direct'
-  s.add_dependency 'cul-folio-edge'
+  s.add_dependency 'cul-folio-edge', ['>= 1.2.1']
 
   s.add_development_dependency "sqlite3"
 end

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,8 @@
 
 ## v2.1.2
 - Don't add links to checkout titles from Borrow Direct, but indicate BD titles with badges (DISCOVERYACCESS-7360)
+- Cache FOLIO auth token to reduce number of API calls (DISCOVERYACCESS-7318)
+- Require v1.2.1 or higher of cul-folio-edge (for new cancel function signature)
 
 ## v2.1.1
 - Guard against null results from ILLiad lookup


### PR DESCRIPTION
- Don't add links to checkout titles from Borrow Direct, but indicate BD titles with badges (DISCOVERYACCESS-7360)
- Cache FOLIO auth token to reduce number of API calls (DISCOVERYACCESS-7318)
- Require v1.2.1 or higher of cul-folio-edge (for new cancel function signature)