### PR TITLE
DISCOVERYACCESS-7436 - omniauth requires POST now, and Rails has new …

### DIFF
--- a/app/controllers/my_account/account_controller.rb
+++ b/app/controllers/my_account/account_controller.rb
@@ -31,7 +31,13 @@ module MyAccount
         if ENV['DEBUG_USER'] && Rails.env.development?
           index
         else
-          redirect_to "#{request.protocol}#{request.host_with_port}/users/auth/saml"
+          # Omniauth gem requirements
+          uri = URI(request.original_url)
+          scheme_host = "#{uri.scheme}://#{uri.host}"
+          if uri.port.present? && uri.port !=  uri.default_port()
+            scheme_host = scheme_host + ':' + uri.port.to_s
+          end
+          redirect_post("#{scheme_host}/users/auth/saml", options: {authenticity_token: :auto})
         end
       end
     end


### PR DESCRIPTION
…request fields
This adds some code to app/controllers/my_account/account_controller.rb - same as with the requests gem.
This code builds the current application's URL based on request.original_url. The previous code used request fields that are no longer available in gem 'rails', '5.2.6.3'.
This also uses the redirect_post replacement for redirect_to from https://github.com/vergilet/repost
The sends the request to omniauth via POST instead of GET - a new requirement.