### PR TITLE
DISCOVERYACCESS-7511: Strip out YAML alert code

### DIFF
--- a/app/controllers/my_account/account_controller.rb
+++ b/app/controllers/my_account/account_controller.rb
@@ -59,20 +59,6 @@ module MyAccount
       end
 
       @netid = user
-
-      # Check for alert messages in alerts.yaml
-      begin
-        alert_messages = YAML.load_file("#{Rails.root}/alerts.yaml")
-        # Each message in the YAML file should have a pages array that lists which pages (e.g., MyAccount, Requests)
-        # should show the alert, and a message property that contains the actual message text/HTML. Only show
-        # the messages for the proper page.
-        @alerts = alert_messages.select{|m| m['pages']&.include?('MyAccount')}.map{|m| m['message']}
-      rescue Errno::ENOENT, Psych::SyntaxError
-        # Nothing to do here; the alerts file is optional, and its absence (Errno::ENOENT) just means that there
-        # are no alert messages to show today. Psych::SyntaxError means there was an error in the syntax
-        # (most likely the indentation) of the YAML file. That's not good, but crashing with an ugly
-        # error message is worse than not showing the alerts.
-      end
     end
 
     # Return a FOLIO authentication token for API calls -- either from the session if a token

--- a/app/views/my_account/account/index.html.haml
+++ b/app/views/my_account/account/index.html.haml
@@ -10,14 +10,6 @@
 - if @netid.nil?
   %p ERROR: Your account information could not be retrieved. Please ask a librarian for help or report this using the feedback link below.
 - else
-  - if @alerts.present?
-    %div.service-alert
-      %div.alert.alert-warning
-        - @alerts.each do |alert|
-          %p
-          = alert.try(:html_safe)
-        %p
-    %br
   %h2#userName 
 
   %ul.nav.nav-tabs{:role => "tablist"}

--- a/lib/my_account/engine.rb
+++ b/lib/my_account/engine.rb
@@ -7,6 +7,12 @@ module MyAccount
     config.assets.paths << config.root.join('/engines/my_account/app/assets/javascripts')
     config.assets.precompile << "my_account/application.js"
     config.assets.precompile << "my_account/account.js.coffee"
+
+    config.to_prepare do
+      # Make the main Blacklight app's helpers available to the engine.
+      # This is required for the overriding of engine views and helpers to work correctly.
+      Engine::ApplicationController.helper Rails.application.helpers
+    end
   end
 
   def self.config(&block)

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,7 +1,8 @@
 # Release Notes - my-account
 
 ## v2.2.3
-- Fix bug in shipped date calculation that prevented requests from loading.
+- Strip out YAML alert code (use the code in the main Blacklight template instead).
+- Fix bug in shipped date calculation that prevented requests from loading (DISCOVERYACCESS-7999).
 
 ## v2.2.2
 ### Improvements


### PR DESCRIPTION
... and use the alerts from the main Blacklight app instead.