### PR TITLE
DISCOVERYACCESS-8043: Remove link to Borrow Direct resolver script

### DIFF
--- a/app/views/my_account/account/_pending_requests.html.haml
+++ b/app/views/my_account/account/_pending_requests.html.haml
@@ -1,6 +1,6 @@
 - request_types = {'H' => 'Hold', 'R' => 'Recall', 'illiad' => 'Interlibrary Loan', 'bd' => 'Borrow Direct', 'C' => 'Call slip'}
 - has_bd_pending = false
-- has_ill_pending = false
+- has_ill_pending = true
 
 - if @pending_requests.length == 0 
   %p
@@ -51,14 +51,9 @@
     %span{:id => 'request-loading-spinner'}
 
 
-- if has_ill_pending
+- if has_ill_pending || has_bd_pending
   %p
-    Need to cancel an Interlibrary loan request? Go to 
+    Need to cancel a Borrow Direct or Interlibrary Loan request? Go to 
     %a{:href => "https://cornell.hosts.atlas-sys.com/illiad"} 
       ILLiad
-- if has_bd_pending
-  %p
-    Need to cancel a Borrow Direct request? Go to 
-    %a{:href => "http://resolver.library.cornell.edu/NET/parsebd?redirect=yes"}
-      Borrow Direct
  

--- a/app/views/my_account/account/_pending_requests.html.haml
+++ b/app/views/my_account/account/_pending_requests.html.haml
@@ -1,6 +1,6 @@
 - request_types = {'H' => 'Hold', 'R' => 'Recall', 'illiad' => 'Interlibrary Loan', 'bd' => 'Borrow Direct', 'C' => 'Call slip'}
 - has_bd_pending = false
-- has_ill_pending = true
+- has_ill_pending = false
 
 - if @pending_requests.length == 0 
   %p

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,8 @@
 # Release Notes - my-account
 
+## IN PROGRESS
+- Remove link to Borrow Direct resolver script (DISCOVERYACCESS-8043)
+
 ## v2.2.3
 - Strip out YAML alert code (use the code in the main Blacklight template instead).
 - Fix bug in shipped date calculation that prevented requests from loading (DISCOVERYACCESS-7999).


### PR DESCRIPTION
ILLiad is used now for all BD or ILL request cancellations, so we don't need a separate link to Borrow Direct. This doesn't solve the underlying issue reported of the old parsebd script misbehaving, but it should keep people from getting to that script from My Account.