### PR TITLE
DISCOVERYACCESS-8164: Guard against empty ReShare records

### DIFF
--- a/app/controllers/my_account/account_controller.rb
+++ b/app/controllers/my_account/account_controller.rb
@@ -352,6 +352,7 @@ module MyAccount
         author = ''
         marc = XmlSimple.xml_in(item['bibRecord'])
         record = marc['GetRecord'][0]['record'][0]
+        # It can happen that, in rare cases, the metadata section is completely missing from the record.
         fields = record.dig('metadata', 0, 'record', 0, 'datafield')
         if fields
           f245 = fields.find { |f| f['tag'] == '245' }

--- a/app/controllers/my_account/account_controller.rb
+++ b/app/controllers/my_account/account_controller.rb
@@ -348,15 +348,21 @@ module MyAccount
 
         # HACK: This is a terrible way to obtain the item title and author. Unfortunately, this information isn't surfaced
         # in the API response, but only provided as part of a marcxml description of the entire item record.
+        title = ''
+        author = ''
         marc = XmlSimple.xml_in(item['bibRecord'])
-        f245 = marc['GetRecord'][0]['record'][0]['metadata'][0]['record'][0]['datafield'].find { |t| t['tag'] == '245' }
-        f245a = f245 && f245['subfield'].find { |sf| sf['code'] == 'a' }
-        f245b = f245 && f245['subfield'].find { |sf| sf['code'] == 'b' }
-        title = f245b ? "#{f245a['content']} #{f245b['content']}" : f245a['content']
+        record = marc['GetRecord'][0]['record'][0]
+        fields = record.dig('metadata', 0, 'record', 0, 'datafield')
+        if fields
+          f245 = fields.find { |f| f['tag'] == '245' }
+          f245a = f245 && f245['subfield'].find { |sf| sf['code'] == 'a' }
+          f245b = f245 && f245['subfield'].find { |sf| sf['code'] == 'b' }
+          title = f245b ? "#{f245a['content']} #{f245b['content']}" : f245a['content']
 
-        f100 = marc['GetRecord'][0]['record'][0]['metadata'][0]['record'][0]['datafield'].find { |t| t['tag'] == '100' }
-        f100a = f100 && f100['subfield'].find { |sf| sf['code'] == 'a' }
-        author = f100a ? "#{f100a['content']}" : ''
+          f100 = fields.find { |t| t['tag'] == '100' }
+          f100a = f100 && f100['subfield'].find { |sf| sf['code'] == 'a' }
+          author = f100a ? "#{f100a['content']}" : ''
+        end
 
         # For the final item, we add a fake item ID number (iid) for compatibility with other items in the system
         # ReShare status *stages* are defined here: 
@@ -374,6 +380,7 @@ module MyAccount
           'shipped' => reshare_shipped_status(item)
         }
       end
+
       session[netid + '_bd_items'] = cleaned_items
       render json: cleaned_items
     end

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,7 @@
 
 ## IN PROGRESS
 - Remove link to Borrow Direct resolver script (DISCOVERYACCESS-8043)
+- Guard against empty(ish) ReShare records (DISCOVERYACCESS-8164)
 
 ## v2.2.3
 - Strip out YAML alert code (use the code in the main Blacklight template instead).


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DISCOVERYACCESS-8164

This part of the My Account code fumbles through an XML representation of a MARC record from ReShare to try to piece together a title and author name(s) to display to a user for items requested from Borrow Direct (ReShare) or ILL.

This particular user somehow has a record request that has no metadata section at all, and so the fragile traversing of the XML broke and caused an error. (In My Account, which is largely AJAX-driven, this commonly manifests as a part of the user account not appearing in the UI.) The proposed solution is still not great, but it's better than what was there before.