### PR TITLE
Merge changes for v2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ gemspec
 gem 'rails', '~>6.1'
 gem 'unf_ext'
 
-#gem 'cul-folio-edge', :path => '/Users/matt/code/cul/d&a/cul-folio-edge'
-gem 'cul-folio-edge', :git => 'https://github.com/cul-it/cul-folio-edge'
+# gem 'cul-folio-edge', :path => '/Users/matt/code/cul/d&a/cul-folio-edge'
+gem 'cul-folio-edge', git: 'https://github.com/cul-it/cul-folio-edge'

--- a/app/helpers/my_account/my_account_helper.rb
+++ b/app/helpers/my_account/my_account_helper.rb
@@ -14,7 +14,7 @@ module MyAccount
       # but indicates an actual library location for Voyager records.
       # item['lo'] == '' || item['TransactionNumber'] ?
       #   display_title :
-      #   link_to(display_title, "https://newcatalog.library.cornell.edu/catalog/#{item['bid']}") 
+      #   link_to(display_title, "https://catalog.library.cornell.edu/catalog/#{item['bid']}") 
     end
 
     # Return a user-readable item status message. This will filter out the 'pahr' statuses that turn

--- a/app/views/my_account/account/_fines.html.haml
+++ b/app/views/my_account/account/_fines.html.haml
@@ -21,4 +21,4 @@
           %td
             = number_to_currency(f['chargeAmount']['amount'])
 %p
-= link_to "View fine rates", "https://newcatalog.library.cornell.edu/myaccount/login"
+= link_to "View fine rates", "https://catalog.library.cornell.edu/myaccount/login"

--- a/lib/my_account/version.rb
+++ b/lib/my_account/version.rb
@@ -1,3 +1,3 @@
 module MyAccount
-  VERSION = "2.2.5"
+  VERSION = '2.3'
 end

--- a/my_account.gemspec
+++ b/my_account.gemspec
@@ -1,7 +1,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 
 # Maintain your gem's version:
-require "my_account/version"
+require 'my_account/version'
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
@@ -9,20 +9,19 @@ Gem::Specification.new do |s|
   s.version     = MyAccount::VERSION
   s.authors     = ["Matt Connolly"]
   s.email       = ["mjc12@cornell.edu"]
-  s.homepage    = "http://newcatalog.library.cornell.edu/myaccount"
-  s.summary     = "Summary of MyAccount."
-  s.description = "Description of MyAccount."
+  s.homepage    = "http://catalog.library.cornell.edu/myaccount"
+  s.summary     = "User account page for Cornell University Library online catalog"
+  s.description = "Provides a user account page for the Cornell University Library online catalog, including user account information, loans, requests, and fines." 
   s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 6.1"
+  s.add_dependency 'rails', '~> 6.1'
   s.add_dependency 'blacklight',['>= 7.0']
-  s.add_dependency "xml-simple"
+  s.add_dependency 'xml-simple'
   s.add_dependency 'rest-client'
-  s.add_dependency 'borrow_direct'
-  s.add_dependency 'cul-folio-edge', ['>= 1.2.1']
+  s.add_dependency 'cul-folio-edge', '~3.1'
 
   s.add_development_dependency "sqlite3"
 end

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,13 @@
 # Release Notes - my-account
 
+## [2.3] - 2024-08-12
+
+### Changed
+- Require v3.1 of `cul-folio-edge` to use new authentication tokens (DACCESS-261)
+- Update catalog links to remove obsolete `newcatalog` qualifier
+
+### Removed
+- Obsolete dependency on `borrow_direct`
 
 ## v2.2.5
 - Change spelling of "Borrow Direct" to "BorrowDirect"


### PR DESCRIPTION
* FOLIO token changes, authenticate returns a token expiration

* Require latest version of cul_folio_edge; remove borrow_direct dependency (DACCESS-261)

* Formatting

* Remove 'newcatalog' references
