### PR TITLE
Fix caching problem with new FOLIO auth scheme

### DIFF
--- a/app/controllers/my_account/account_controller.rb
+++ b/app/controllers/my_account/account_controller.rb
@@ -63,8 +63,11 @@ module MyAccount
 
     # Return a FOLIO authentication token for API calls -- either from the session if a token
     # was previously created, or has expired, or directly from FOLIO otherwise.
+    #
+    # TODO: Caching is being disabled for now, since it's causing problems with the new expiring
+    # token mechanism in FOLIO. We need to figure out how to cache the token properly. (mjc12)
     def folio_token
-      if session[:folio_token].nil? || (session[:folio_token_exp].present? && Time.now > Time.parse(session[:folio_token_exp]))
+      # if session[:folio_token].nil? || (session[:folio_token_exp].present? && Time.now > Time.parse(session[:folio_token_exp]))
         url = ENV['OKAPI_URL']
         tenant = ENV['OKAPI_TENANT']
         response = CUL::FOLIO::Edge.authenticate(url, tenant, ENV['OKAPI_USER'], ENV['OKAPI_PW'])
@@ -74,7 +77,7 @@ module MyAccount
           session[:folio_token] = response[:token]
           session[:folio_token_exp] = response[:token_exp]
         end
-      end
+      # end
       session[:folio_token]
     end
 

--- a/lib/my_account/version.rb
+++ b/lib/my_account/version.rb
@@ -1,3 +1,3 @@
 module MyAccount
-  VERSION = '2.3.1'
+  VERSION = '2.3.2'
 end

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,10 @@
 # Release Notes - my-account
 
+## [2.3.2] - 2024-08-26
+
+### Fixed
+- New FOLIO token auth scheme causing problems because of token caching; caching disabled for now
+
 ## [2.3.1] - 2024-08-20
 
 ### Fixed


### PR DESCRIPTION
The new FOLIO token authentication scheme, which we started using last week, is causing unexpected problems because of the way that My Account is trying to cache the token in the Rails session. As a quick fix, this PR disables caching entirely. We'll have to figure out the right way to do it later.