### PR TITLE
DACCESS-459: Fix bug breaking ReShare lookups

### DIFF
--- a/app/controllers/my_account/account_controller.rb
+++ b/app/controllers/my_account/account_controller.rb
@@ -315,7 +315,7 @@ module MyAccount
 
       begin
         token = nil
-        response = CUL::FOLIO::Edge.authenticate(ENV['RESHARE_STATUS_URL'], ENV['RESHARE_TENANT'], ENV['RESHARE_USER'], ENV['RESHARE_PW'])
+        response = CUL::FOLIO::Edge.authenticate(ENV['RESHARE_STATUS_URL'], ENV['RESHARE_TENANT'], ENV['RESHARE_USER'], ENV['RESHARE_PW'], method: :old)
         if response[:code] >= 300
           Rails.logger.error "MyAccount error: Could not create a ReShare token for #{ENV['RESHARE_USER']}"
         else

--- a/my_account.gemspec
+++ b/my_account.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'blacklight',['>= 7.0']
   s.add_dependency 'xml-simple'
   s.add_dependency 'rest-client'
-  s.add_dependency 'cul-folio-edge', '~> 3.1'
+  s.add_dependency 'cul-folio-edge', '~> 3.2'
 
   s.add_development_dependency "sqlite3"
 end

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,9 @@
 # Release Notes - my-account
 
+## IN PROGRESS
+### Fixed
+- Specify old authentication method to fix broken ReShare account lookup (DACCESS-459)
+
 ## [2.3.3] - 2024-09-17
 - Update links to fine information
 


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-459

ReShare requests are broken because ReShare has not updated to use the newer form of FOLIO token authentication. Therefore, we have to use an updated version of the `cul-folio-edge` library that lets us specify which version of authentication to use.