### PR TITLE
DACCESS-257: Fix bug preventing ILL requests from appearing

### DIFF
--- a/app/controllers/my_account/account_controller.rb
+++ b/app/controllers/my_account/account_controller.rb
@@ -315,7 +315,7 @@ module MyAccount
 
       begin
         token = nil
-        response = CUL::FOLIO::Edge.authenticate(ENV['RESHARE_STATUS_URL'], ENV['RESHARE_TENANT'], ENV['RESHARE_USER'], ENV['RESHARE_PW'])
+        response = CUL::FOLIO::Edge.authenticate(ENV['RESHARE_STATUS_URL'], ENV['RESHARE_TENANT'], ENV['RESHARE_USER'], ENV['RESHARE_PW'], method: :old)
         if response[:code] >= 300
           Rails.logger.error "MyAccount error: Could not create a ReShare token for #{ENV['RESHARE_USER']}"
         else

--- a/lib/ill.rb
+++ b/lib/ill.rb
@@ -3,7 +3,7 @@ module ILL
   
   def ill_transactions(user_id)
     transactions = fetch_ill_transactions(user_id)
-    transactions = filter_by_status(transactions)
+    #transactions = filter_by_status(transactions)
     transform_fields(transactions)
   end
 
@@ -68,8 +68,8 @@ module ILL
       location = transaction['NVTGC']
       due_date = transaction['DueDate']
       original_due_date = transaction['DueDate']
-      renewals_allowed = transaction['RenewalsAllowed']
-      date = due_date
+      # renewals_allowed = transaction['RenewalsAllowed']
+      # date = due_date
 
       status = transaction['TransactionStatus']
       case status
@@ -89,9 +89,7 @@ module ILL
         url = "https://cornell.hosts.atlas-sys.com/illiad/illiad.dll?Action=10&Form=63&Value=#{transaction['TransactionNumber']}"
       end
 
-      transaction_number = transaction['TransactionNumber']
-      document_type = transaction['DocumentType']
-
+      # TODO: Review these fields ... some of them are probably unnecessary.
       {
         system: "illiad",
         status: status,
@@ -104,13 +102,16 @@ module ILL
         ou_genre: genre,
         ou_title: title,
         ou_aulast: author_last_name,
-        ou_pages: pages,
-        ou_year: year,
-        ou_issue: issue,
-        ou_volume: volume,
-        ou_issn: issn,
+        # The following fields don't seem to be used anywhere.
+        # ou_pages: pages,
+        # ou_year: year,
+        # ou_issue: issue,
+        # ou_volume: volume,
+        # ou_issn: issn,
         url: url,
-        requestDate: transaction['CreationDate']
+        requestDate: transaction['CreationDate'],
+        TransactionDate: transaction['TransactionDate'],
+        TransactionNumber: transaction['TransactionNumber']
       }
     end
 

--- a/lib/ill.rb
+++ b/lib/ill.rb
@@ -1,0 +1,125 @@
+module ILL
+  require 'rest-client'
+  
+  def ill_transactions(user_id)
+    transactions = fetch_ill_transactions(user_id)
+    #transactions = filter_by_status(transactions)
+    add_fields(transactions)
+  end
+
+  private
+
+  # Fetches ILL (Interlibrary Loan) transactions for a given user via the ILLiad API.
+  #
+  # @param user_id [String] the ID of the user whose transactions are being fetched (netid or guest id)
+  # @return [Array<Hash>] an array of objects representing the user's ILL transactions.
+  # @raise [RestClient::ExceptionWithResponse] if the request to the ILLiad API fails.
+  #
+  # The method sends a GET request to the ILLiad API to retrieve the user's ILL transactions.
+  # It expects the API key and URL to be set in the environment variables 'MY_ACCOUNT_ILLIAD_API_KEY' and 'MY_ACCOUNT_ILLIAD_API_URL'.
+  def fetch_ill_transactions(user_id)
+    headers = {
+      'Accept' => 'application/json',
+      'APIKey' => ENV['MY_ACCOUNT_ILLIAD_API_KEY']
+    }
+    response = RestClient.get "#{ENV['MY_ACCOUNT_ILLIAD_API_URL']}/Transaction/UserRequests/#{user_id}", headers
+    transactions = JSON.parse(response.body)
+    transactions
+  end
+
+  # Remove transactions that are completed or cancelled
+  def filter_by_status(transactions)
+    transactions.select do |transaction|
+      !['Request Finished', 'Cancelled by ILL Staff', 'Cancelled by Customer'].include?(transaction['TransactionStatus'])
+    end
+  end
+
+  # Add custom fields to each transaction. These are primarily used for display in the My Account requests views.
+  # This method is a near-direct port of the illiad6.cgi Perl script that was previously used as a data source for ILLiad.
+  # illiad6.cgi directly queried the ILLiad database, then added these fields to the results before passing
+  # the whole thing back as a response. Why do we have ii, ou_genre, etc. as fields? Do we still need them
+  # to be this obscure? Can we make them more readable? These are questions to ponder in the future.
+  def add_fields(transactions)
+    response = "{\"items\": [\n"
+    items_array = []
+    transactions.each do |transaction|
+      tags_array = []
+
+      genre = transaction['LoanTitle'] ? 'book' : 'article'
+      title = transaction['LoanTitle'] || transaction['PhotoArticleTitle']
+      title.gsub!(/"/, ' ')
+      spot = title.index('/')
+      title = title[0...spot - 1] if spot
+
+      if genre == 'article'
+        author_last_name = transaction['PhotoArticleAuthor']
+        volume = transaction['PhotoJournalVolume']
+        issn = transaction['ISSN']
+        issue = transaction['PhotoJournalIssue']
+        year = transaction['PhotoJournalYear']
+        pages = transaction['PhotoJournalInclusivePages']
+        full_title = "#{transaction['PhotoJournalTitle']} #{transaction['PhotoArticleTitle']} / #{transaction['PhotoArticleAuthor']} v.#{transaction['PhotoJournalVolume']} # #{transaction['PhotoJournalIssue']} pp. #{transaction['PhotoJournalInclusivePages']} #{transaction['PhotoJournalYear']}"
+      else
+        author_last_name = transaction['LoanAuthor']
+        year = transaction['LoanDate']
+        isbn = transaction['ISSN']
+        spot = transaction['LoanTitle'].index('/')
+        transaction['LoanTitle'] = transaction['LoanTitle'][0...spot - 1] if spot
+        full_title = "#{transaction['LoanTitle']} / #{transaction['LoanAuthor']}"
+      end
+
+      #full_title.gsub!(/[\012\015]/, ' ').gsub!(/"/, ' ').gsub!(/"/, "'")
+      location = transaction['NVTGC']
+      due_date = transaction['DueDate']
+      original_due_date = transaction['DueDate']
+      renewals_allowed = transaction['RenewalsAllowed']
+      date = due_date
+
+      status = transaction['TransactionStatus']
+      case status
+      when 'Checked Out to Customer', 'Renewal Requested by Customer'
+        status = "chrged"
+        url = "https://cornell.hosts.atlas-sys.com/illiad/illiad.dll?Action=10&Form=66&Value=#{transaction['TransactionNumber']}"
+      when 'Awaiting Verisign Payment'
+        status = "waiting"
+        url = "https://cornell.hosts.atlas-sys.com/illiad/illiad.dll?Action=10&Form=62"
+      when 'Delivered to Web'
+        status = "waiting"
+        url = "https://cornell.hosts.atlas-sys.com/illiad/illiad.dll?Action=10&Form=75&Value=#{transaction['TransactionNumber']}"
+      when 'Customer Notified via E-Mail'
+        status = "waiting"
+      else
+        status = "pahr"
+        url = "https://cornell.hosts.atlas-sys.com/illiad/illiad.dll?Action=10&Form=63&Value=#{transaction['TransactionNumber']}"
+      end
+
+      transaction_number = transaction['TransactionNumber']
+      document_type = transaction['DocumentType']
+
+      tags_array << "\"system\":\"illiad\""
+      tags_array << "\"status\":\"#{status}\""
+      tags_array << "\"ii\":\"#{transaction_number}\""
+      tags_array << "\"it\":\"#{document_type}\""
+      tags_array << "\"tl\":\"#{full_title}\""
+      tags_array << "\"od\":\"#{original_due_date}\""
+      tags_array << "\"rd\":\"#{due_date}\""
+      tags_array << "\"lo\":\"#{location}\""
+      tags_array << "\"ou_genre\":\"#{genre}\""
+      tags_array << "\"ou_title\":\"#{title}\""
+      tags_array << "\"ou_aulast\":\"#{author_last_name}\""
+      tags_array << "\"ou_pages\":\"#{pages}\""
+      tags_array << "\"ou_year\":\"#{year}\""
+      tags_array << "\"ou_issue\":\"#{issue}\""
+      tags_array << "\"ou_volume\":\"#{volume}\""
+      tags_array << "\"ou_issn\":\"#{issn}\""
+      tags_array << "\"url\":\"#{url}\""
+    
+      items_array << "{#{tags_array.join(",\n")}}"
+    end
+
+    response += items_array.join(",\n")
+    response += "\n]\n}"
+    response
+  end
+
+end

--- a/lib/my_account/engine.rb
+++ b/lib/my_account/engine.rb
@@ -3,7 +3,8 @@ module MyAccount
     isolate_namespace MyAccount
 
     config.autoload_paths += Dir["#{config.root}/spec/support"]
-    config.eager_load_paths += Dir["#{config.root}/lib"]
+    config.autoload_paths += Dir["#{config.root}/lib/**/"]
+    config.eager_load_paths += Dir["#{config.root}/lib/**/"]
     config.assets.paths << config.root.join('/engines/my_account/app/assets/javascripts')
     config.assets.precompile << "my_account/application.js"
     config.assets.precompile << "my_account/account.js.coffee"

--- a/my_account.gemspec
+++ b/my_account.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'blacklight',['>= 7.0']
   s.add_dependency 'xml-simple'
   s.add_dependency 'rest-client'
-  s.add_dependency 'cul-folio-edge', '~> 3.1'
+  s.add_dependency 'cul-folio-edge', '~> 3.2'
 
   s.add_development_dependency "sqlite3"
 end

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fix punctuation on login page
+- Specify old authentication method to fix broken ReShare account lookup (DACCESS-459)
 
 ## [2.3.3] - 2024-09-17
 - Update links to fine information

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,10 +1,13 @@
 # Release Notes - my-account
 
 ## In Progress
+### Changed
+- Remove dependency on external CGI script for ILLiad lookups by adding new ILL module using ILL API (DACCESS-257)
 
 ### Fixed
 - Fix punctuation on login page
 - Specify old authentication method to fix broken ReShare account lookup (DACCESS-459)
+- Fix bug preventing ILLiad requests from appearing (DACCESS-460)
 
 ## [2.3.3] - 2024-09-17
 - Update links to fine information


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-460
https://culibrary.atlassian.net/browse/DACCESS-257

This bug, which prevents ILLiad requests from appearing, is due to our dependency on the external illiad6.cgi script as an ILLiad data source. At some point in the recent past, the script began to return invalid JSON that the My Account code can't process. Since we've been meaning to eliminate the CGI dependency for a while now, this seemed to be the time to do that.

I've added a new ILL module under /lib that does most of the work. The ILLiad API makes the lookup and retrieval straightforward. The URL and API key are kept in two new .env vars, `MY_ACCOUNT_ILLIAD_API_KEY` and `MY_ACCOUNT_ILLIAD_API_URL`. 

However, the CGI script also does some arcane data massaging that replaces the incoming ILLiad request ("transaction") object with a completely different one. I'm not sure why. I've ported over most of the same logic for the time being, since it works with the existing My Account code, but this would be something to review in the future to see if we can further simplify it.